### PR TITLE
Raise iOS deployment target for Google Navigation

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,6 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '16.0.0'
+# Raised to 16.0 to satisfy Google Navigation SDK requirements.
+platform :ios, '16.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -39,8 +40,9 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
-      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
-      
+      # Ensure all pods build with iOS 16.0 deployment target for Google
+      # Navigation and Google Maps SDK.
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Raise Podfile platform to iOS 16.0 for Google Navigation SDK
- Ensure all pods build with iOS 16.0 deployment target

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba03fe37888331b74e86fab3c938ea