### PR TITLE
feat: use native google maps turn by turn

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,8 +73,6 @@ dependencies:
   google_maps_flutter_ios: 2.15.2
   google_maps_flutter_platform_interface: 2.12.1
   google_maps_flutter_web: 0.5.12
-  # Downgrade to a version compatible with GoogleMaps < 10.0
-  google_navigation_flutter: 0.5.2
   google_sign_in: 6.3.0
   google_sign_in_android: 6.2.1
   google_sign_in_ios: 5.9.0


### PR DESCRIPTION
## Summary
- switch TurnByTurn widget to use native `google_maps_flutter` with Directions API
- drop google_navigation_flutter dependency

## Testing
- `dart format lib/custom_code/widgets/turn_by_turn_nav.dart pubspec.yaml` *(fail: command not found)*
- `flutter test` *(fail: command not found)*
- `apt-get install -y dart` *(fail: package not found)*
- `apt-get install -y flutter` *(fail: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bac60d965c83319d21a05832826f72