### PR TITLE
feat: add voice-guided 3D navigation

### DIFF
--- a/lib/driver_on_ride/driver_on_ride_widget.dart
+++ b/lib/driver_on_ride/driver_on_ride_widget.dart
@@ -133,7 +133,7 @@ class _DriverOnRideWidgetState extends State<DriverOnRideWidget> {
                         apiKey: 'AIzaSyCFBfcNHFg97sM7EhKnAP4OHIoY3Q8Y_xQ',
                         arrivalRadiusMeters: 30.0,
                         simulateIfNoGPS: false,
-                        useDeviceCompass: false,
+                        useDeviceCompass: true,
                         userLatLng: driverOnRideRideOrdersRecord.latlngAtual!,
                         initialDriverLatLng: currentUserDocument?.location,
                         placeLatLng: driverOnRideRideOrdersRecord.latlng!,


### PR DESCRIPTION
## Summary
- add speech-guided navigation with step parsing
- support dark styled maps, yellow route and compass-based 3D camera
- enable compass navigation in DriverOnRide widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bad3c017f88331876d38f4b9e4797c