### PR TITLE
feat(nav): external Google navigation button and Firestore sync

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,6 +50,11 @@
     <string>$(FLUTTER_BUILD_NUMBER)</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <!-- Allow checking if Google Maps app is installed -->
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>comgooglemaps</string>
+    </array>
     <!-- **** LOCATION PERMISSIONS (English) ****
          Needed for GPS + heading (compass via CoreLocation) while app is in use. -->
     <key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
## Summary
- add Google navigation button to TurnByTurnNav preview
- sync driver position with Firestore and rotate marker using heading
- allow iOS to query comgooglemaps scheme

## Testing
- `dart format lib/custom_code/widgets/turn_by_turn_nav.dart ios/Runner/Info.plist` *(fails: command not found)*
- `dart analyze lib/custom_code/widgets/turn_by_turn_nav.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68baf9e3c54c8331924748dd9c27141e