### PR TITLE
feat: add native turn-by-turn navigation view

### DIFF
--- a/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -1,6 +1,14 @@
 package com.quicky.ridedriver
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
 class MainActivity: FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        flutterEngine
+            .platformViewsController
+            .registry
+            .registerViewFactory("NativeTurnByTurnNav", NativeTurnByTurnNavFactory())
+    }
 }

--- a/android/app/src/main/kotlin/com/example/my_project/NativeTurnByTurnNav.kt
+++ b/android/app/src/main/kotlin/com/example/my_project/NativeTurnByTurnNav.kt
@@ -1,0 +1,53 @@
+package com.quicky.ridedriver
+
+import android.content.Context
+import android.view.View
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.MapView
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+import io.flutter.plugin.common.StandardMessageCodec
+
+class NativeTurnByTurnNavFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+    override fun create(context: Context, id: Int, args: Any?): PlatformView {
+        val params = args as? Map<String, Any>
+        return NativeTurnByTurnNav(context, params)
+    }
+}
+
+class NativeTurnByTurnNav(context: Context, params: Map<String, Any>?) : PlatformView, OnMapReadyCallback {
+    private val mapView: MapView = MapView(context)
+    private var map: GoogleMap? = null
+    private val dest: LatLng? = params?.let {
+        val lat = it["destLat"] as? Double
+        val lng = it["destLng"] as? Double
+        if (lat != null && lng != null) LatLng(lat, lng) else null
+    }
+
+    init {
+        mapView.onCreate(null)
+        mapView.getMapAsync(this)
+    }
+
+    override fun getView(): View = mapView
+
+    override fun dispose() {
+        mapView.onDestroy()
+    }
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        MapsInitializer.initialize(mapView.context)
+        map = googleMap
+        map?.uiSettings?.isCompassEnabled = true
+        map?.isMyLocationEnabled = true
+        dest?.let {
+            map?.addMarker(MarkerOptions().position(it))
+            map?.moveCamera(CameraUpdateFactory.newLatLngZoom(it, 15f))
+        }
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,6 +10,10 @@ import GoogleMaps
   ) -> Bool {
     GMSServices.provideAPIKey("AIzaSyCFBfcNHFg97sM7EhKnAP4OHIoY3Q8Y_xQ")
     GeneratedPluginRegistrant.register(with: self)
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let factory = NativeTurnByTurnNavFactory(messenger: controller.binaryMessenger)
+      registrar(forPlugin: "NativeTurnByTurnNav")?.register(factory, withId: "NativeTurnByTurnNav")
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/ios/Runner/NativeTurnByTurnNavFactory.swift
+++ b/ios/Runner/NativeTurnByTurnNavFactory.swift
@@ -1,0 +1,40 @@
+import Flutter
+import UIKit
+import MapKit
+
+class NativeTurnByTurnNavFactory: NSObject, FlutterPlatformViewFactory {
+  private var messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func create(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?) -> FlutterPlatformView {
+    return NativeTurnByTurnNav(frame: frame, viewId: viewId, messenger: messenger, args: args)
+  }
+}
+
+class NativeTurnByTurnNav: NSObject, FlutterPlatformView {
+  private var mapView: MKMapView
+
+  init(frame: CGRect, viewId: Int64, messenger: FlutterBinaryMessenger, args: Any?) {
+    mapView = MKMapView(frame: frame)
+    mapView.showsUserLocation = true
+    mapView.showsCompass = true
+    if let dict = args as? [String: Any],
+       let lat = dict["destLat"] as? Double,
+       let lng = dict["destLng"] as? Double {
+      let dest = CLLocationCoordinate2D(latitude: lat, longitude: lng)
+      let annotation = MKPointAnnotation()
+      annotation.coordinate = dest
+      mapView.addAnnotation(annotation)
+      mapView.setRegion(MKCoordinateRegion(center: dest, span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)), animated: false)
+    }
+    super.init()
+  }
+
+  func view() -> UIView {
+    return mapView
+  }
+}

--- a/lib/custom_code/widgets/index.dart
+++ b/lib/custom_code/widgets/index.dart
@@ -1,2 +1,3 @@
 export 'calendar.dart' show Calendar;
 export 'turn_by_turn_nav.dart' show TurnByTurnNav;
+export 'native_turn_by_turn_nav.dart' show NativeTurnByTurnNav;

--- a/lib/custom_code/widgets/native_turn_by_turn_nav.dart
+++ b/lib/custom_code/widgets/native_turn_by_turn_nav.dart
@@ -1,0 +1,77 @@
+// Automatic FlutterFlow imports
+import '/backend/backend.dart';
+import '/actions/actions.dart' as action_blocks;
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'index.dart'; // Imports other custom widgets
+import '/custom_code/actions/index.dart'; // Imports custom actions
+import '/flutter_flow/custom_functions.dart'; // Imports custom functions
+import 'package:flutter/material.dart';
+// Begin custom widget code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+// Native Turn-by-turn navigation using platform views.
+// This widget hosts a native MapView (Google Maps on Android, MapKit on iOS)
+// and displays the destination with the device's compass enabled.
+// API mirrors TurnByTurnNav but uses fully native map views without
+// relying on the google_maps_flutter plugin.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import '/flutter_flow/lat_lng.dart' as ff;
+
+class NativeTurnByTurnNav extends StatelessWidget {
+  const NativeTurnByTurnNav({
+    super.key,
+    required this.userLatLng,
+    required this.placeLatLng,
+    required this.width,
+    required this.height,
+  });
+
+  final ff.LatLng userLatLng;
+  final ff.LatLng placeLatLng;
+  final double width;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    if (kIsWeb) {
+      return const Text('Native navigation not supported on web.');
+    }
+
+    final params = <String, dynamic>{
+      'userLat': userLatLng.latitude,
+      'userLng': userLatLng.longitude,
+      'destLat': placeLatLng.latitude,
+      'destLng': placeLatLng.longitude,
+    };
+
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return SizedBox(
+        width: width,
+        height: height,
+        child: AndroidView(
+          viewType: 'NativeTurnByTurnNav',
+          layoutDirection: TextDirection.ltr,
+          creationParams: params,
+          creationParamsCodec: const StandardMessageCodec(),
+        ),
+      );
+    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return SizedBox(
+        width: width,
+        height: height,
+        child: UiKitView(
+          viewType: 'NativeTurnByTurnNav',
+          layoutDirection: TextDirection.ltr,
+          creationParams: params,
+          creationParamsCodec: const StandardMessageCodec(),
+        ),
+      );
+    }
+
+    return const Text('Native navigation not implemented for this platform.');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add NativeTurnByTurnNav widget that hosts native MapView/MapKit
- register platform view factories on Android and iOS

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c32859fb04833188f0fd8b1de2be70