### PR TITLE
Fix duplicate Google Maps classes in Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,7 +89,6 @@ flutter {
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.0"
-    implementation 'com.google.android.gms:play-services-maps:19.0.0'
     implementation 'com.google.android.gms:play-services-location:21.3.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'


### PR DESCRIPTION
## Summary
- remove direct play-services-maps dependency to avoid class conflicts with Google Navigation

## Testing
- ⚠️ `flutter build apk --debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c349fa710483319521aba4a49f8215