### PR TITLE
fix: supply api key for native navigation widget

### DIFF
--- a/lib/custom_code/widgets/native_turn_by_turn_nav.dart
+++ b/lib/custom_code/widgets/native_turn_by_turn_nav.dart
@@ -23,12 +23,14 @@ import '/flutter_flow/lat_lng.dart' as ff;
 class NativeTurnByTurnNav extends StatelessWidget {
   const NativeTurnByTurnNav({
     super.key,
+    required this.apiKey,
     required this.userLatLng,
     required this.placeLatLng,
     required this.width,
     required this.height,
   });
 
+  final String apiKey;
   final ff.LatLng userLatLng;
   final ff.LatLng placeLatLng;
   final double width;
@@ -45,6 +47,7 @@ class NativeTurnByTurnNav extends StatelessWidget {
       'userLng': userLatLng.longitude,
       'destLat': placeLatLng.latitude,
       'destLng': placeLatLng.longitude,
+      'apiKey': apiKey,
     };
 
     if (defaultTargetPlatform == TargetPlatform.android) {

--- a/lib/driver_on_ride/driver_on_ride_widget.dart
+++ b/lib/driver_on_ride/driver_on_ride_widget.dart
@@ -135,6 +135,7 @@ class _DriverOnRideWidgetState extends State<DriverOnRideWidget> {
                       width: double.infinity,
                       height: double.infinity,
                       child: custom_widgets.NativeTurnByTurnNav(
+                        apiKey: 'AIzaSyCxq0iBKdwc2F7SdBnYCzMhC-nXIMIEyyU',
                         userLatLng: driverOnRideRideOrdersRecord.latlngAtual!,
                         placeLatLng: driverOnRideRideOrdersRecord.latlng!,
                         width: double.infinity,


### PR DESCRIPTION
## Summary
- add required `apiKey` parameter to `NativeTurnByTurnNav`
- provide Google Maps key when using the native navigation widget

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c34d2761308331984412309565f664