### PR TITLE
fix: remove unused model reference from native nav widget

### DIFF
--- a/lib/custom_code/widgets/native_turn_by_turn_nav.dart
+++ b/lib/custom_code/widgets/native_turn_by_turn_nav.dart
@@ -3,7 +3,6 @@ import '/backend/backend.dart';
 import '/actions/actions.dart' as action_blocks;
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import 'index.dart'; // Imports other custom widgets
 import '/custom_code/actions/index.dart'; // Imports custom actions
 import '/flutter_flow/custom_functions.dart'; // Imports custom functions
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Summary
- remove stray FlutterFlow model import from `NativeTurnByTurnNav`

## Testing
- `flutter analyze lib/custom_code/widgets/native_turn_by_turn_nav.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c496622de48331a54b6cd8c4824c4a