### PR TITLE
Fix native turn-by-turn navigation widget

### DIFF
--- a/lib/custom_code/widgets/native_turn_by_turn_nav.dart
+++ b/lib/custom_code/widgets/native_turn_by_turn_nav.dart
@@ -1,24 +1,24 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/backend/backend.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
-import '/flutter_flow/flutter_flow_util.dart';
-import '/custom_code/actions/index.dart'; // Imports custom actions
-import '/flutter_flow/custom_functions.dart'; // Imports custom functions
-import '/custom_code/widgets/index.dart' as custom_widgets;
+import '/flutter_flow/lat_lng.dart' as ff;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
+import 'package:flutter/services.dart';
 
-import 'driver_on_ride_model.dart';
-export 'driver_on_ride_model.dart';
-
-class DriverOnRideWidget extends StatefulWidget {
-  const DriverOnRideWidget({
+/// Displays a native map view for turn-by-turn navigation on Android and iOS.
+///
+/// This widget wraps a platform-specific implementation exposed via
+/// the `NativeTurnByTurnNav` view type. On web and unsupported platforms a
+/// simple placeholder is rendered.
+class NativeTurnByTurnNav extends StatelessWidget {
+  const NativeTurnByTurnNav({
     super.key,
     required this.apiKey,
     required this.userLatLng,
     required this.placeLatLng,
     required this.width,
     required this.height,
+    this.arrivalRadiusMeters = 25,
+    this.useDeviceCompass = true,
+    this.initialDriverLatLng,
   });
 
   final String apiKey;
@@ -26,18 +26,12 @@ class DriverOnRideWidget extends StatefulWidget {
   final ff.LatLng placeLatLng;
   final double width;
   final double height;
-    required this.driverOrder,
-  });
-
-  final DocumentReference? driverOrder;
-
-  static String routeName = 'DriverOnRide';
-  static String routePath = '/driverOnRide';
+  final double arrivalRadiusMeters;
+  final bool useDeviceCompass;
+  final ff.LatLng? initialDriverLatLng;
 
   @override
-  State<DriverOnRideWidget> createState() => _DriverOnRideWidgetState();
-}
-
+  Widget build(BuildContext context) {
     final params = <String, dynamic>{
       'userLat': userLatLng.latitude,
       'userLng': userLatLng.longitude,
@@ -45,108 +39,48 @@ class DriverOnRideWidget extends StatefulWidget {
       'destLng': placeLatLng.longitude,
       'apiKey': apiKey,
     };
-class _DriverOnRideWidgetState extends State<DriverOnRideWidget> {
-  late DriverOnRideModel _model;
 
-  final scaffoldKey = GlobalKey<ScaffoldState>();
-  LatLng? currentUserLocationValue;
-
-  @override
-  void initState() {
-    super.initState();
-    _model = createModel(context, () => DriverOnRideModel());
-
-    getCurrentUserLocation(
-      defaultLocation: const LatLng(0.0, 0.0),
-      cached: true,
-    ).then((loc) => safeSetState(() => currentUserLocationValue = loc));
-  }
-
-  @override
-  void dispose() {
-    _model.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (currentUserLocationValue == null) {
-      return Container(
-        color: FlutterFlowTheme.of(context).primaryBackground,
-        child: Center(
-          child: SizedBox(
-            width: 50.0,
-            height: 50.0,
-            child: CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(
-                FlutterFlowTheme.of(context).primary,
-              ),
-            ),
-          ),
+    if (kIsWeb) {
+      return SizedBox(
+        width: width,
+        height: height,
+        child: const Center(
+          child: Text('Native navigation is not supported on web.'),
         ),
       );
     }
 
-    return StreamBuilder<RideOrdersRecord>(
-      stream: RideOrdersRecord.getDocument(widget.driverOrder!),
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) {
-          return Scaffold(
-            backgroundColor: FlutterFlowTheme.of(context).tertiary,
-            body: Center(
-              child: SizedBox(
-                width: 50.0,
-                height: 50.0,
-                child: CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(
-                    FlutterFlowTheme.of(context).primary,
-                  ),
-                ),
-              ),
-            ),
-          );
-        }
-
-        final driverOnRideRideOrdersRecord = snapshot.data!;
-
-        return GestureDetector(
-          onTap: () {
-            FocusScope.of(context).unfocus();
-            FocusManager.instance.primaryFocus?.unfocus();
-          },
-          child: Scaffold(
-            key: scaffoldKey,
-            resizeToAvoidBottomInset: false,
-            backgroundColor: FlutterFlowTheme.of(context).tertiary,
-            body: Stack(
-              children: [
-                // Apenas o nativo em cima, via PlatformView:
-                PointerInterceptor(
-                  intercepting: isWeb,
-                  child: AuthUserStreamWidget(
-                    builder: (context) => SizedBox(
-                      width: double.infinity,
-                      height: double.infinity,
-                      child: custom_widgets.NativeTurnByTurnNav(
-                        width: double.infinity,
-                        height: double.infinity,
-                        // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                        apiKey: 'AIzaSyCFBfcNHFg97sM7EhKnAP4OHIoY3Q8Y_xQ',
-                        // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                        arrivalRadiusMeters: 30.0,
-                        useDeviceCompass: true,
-                        userLatLng: driverOnRideRideOrdersRecord.latlngAtual!,
-                        initialDriverLatLng: currentUserDocument?.location,
-                        placeLatLng: driverOnRideRideOrdersRecord.latlng!,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return SizedBox(
+          width: width,
+          height: height,
+          child: AndroidView(
+            viewType: 'NativeTurnByTurnNav',
+            layoutDirection: TextDirection.ltr,
+            creationParams: params,
+            creationParamsCodec: const StandardMessageCodec(),
           ),
         );
-      },
-    );
+      case TargetPlatform.iOS:
+        return SizedBox(
+          width: width,
+          height: height,
+          child: UiKitView(
+            viewType: 'NativeTurnByTurnNav',
+            layoutDirection: TextDirection.ltr,
+            creationParams: params,
+            creationParamsCodec: const StandardMessageCodec(),
+          ),
+        );
+      default:
+        return SizedBox(
+          width: width,
+          height: height,
+          child: const Center(
+            child: Text('Native navigation is not supported on this platform.'),
+          ),
+        );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restore NativeTurnByTurnNav widget to wrap native map views

## Testing
- `dart format lib/custom_code/widgets/native_turn_by_turn_nav.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68c49b28f6cc8331a596409773c24f14