### PR TITLE
Resolve Google Maps duplicate class conflict in Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,6 +82,11 @@ android {
     }
 }
 
+configurations.all {
+    exclude group: "com.google.android.gms", module: "play-services-maps"
+}
+
+
 flutter {
     source '../..'
 }


### PR DESCRIPTION
## Summary
- exclude `play-services-maps` from Gradle configurations to prevent duplicate map classes

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68c5b6ad63dc8331b6ab0a1f399a3663